### PR TITLE
Fix ChatGPT battle transition decompression

### DIFF
--- a/graphics_file_rules.mk
+++ b/graphics_file_rules.mk
@@ -384,6 +384,9 @@ $(MASKSGFXDIR)/unused_level_up.4bpp: %.4bpp: %.png
 $(BATTRANSGFXDIR)/vs_frame.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 16 -Wnum_tiles
 
+$(BATTRANSGFXDIR)/chatgpt.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -num_tiles 96 -Wnum_tiles
+
 graphics/party_menu/bg.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 62 -Wnum_tiles
 

--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -343,8 +343,8 @@ static const u32 sFrontierSquares_EmptyBg_Tileset[] = INCBIN_U32("graphics/battl
 static const u32 sFrontierSquares_Shrink1_Tileset[] = INCBIN_U32("graphics/battle_transitions/frontier_square_3.4bpp.smol");
 static const u32 sFrontierSquares_Shrink2_Tileset[] = INCBIN_U32("graphics/battle_transitions/frontier_square_4.4bpp.smol");
 static const u32 sFrontierSquares_Tilemap[] = INCBIN_U32("graphics/battle_transitions/frontier_squares.bin");
-const u32 sChatGPT_Tileset[] = INCBIN_U32("graphics/battle_transitions/chatgpt.4bpp.lz");
-const u32 sChatGPT_Tilemap[] = INCBIN_U32("graphics/battle_transitions/chatgpt.bin.lz");
+const u32 sChatGPT_Tileset[] = INCBIN_U32("graphics/battle_transitions/chatgpt.4bpp.smol");
+const u32 sChatGPT_Tilemap[] = INCBIN_U32("graphics/battle_transitions/chatgpt.bin.smolTM");
 const u16 sChatGPT_Palette[] = INCBIN_U16("graphics/battle_transitions/chatgpt.gbapal");
 
 // All battle transitions use the same intro
@@ -1833,7 +1833,7 @@ bool8 ChatGPT_Init(struct Task *task)
     InitPatternWeaveTransition(task);
     GetBg0TilesDst(&tilemap, &tileset);
     CpuFill16(0, tilemap, BG_SCREEN_SIZE);
-    LZ77UnCompVram(sChatGPT_Tileset, tileset);
+    DecompressDataWithHeaderVram(sChatGPT_Tileset, tileset);
     LoadPalette(sChatGPT_Palette, BG_PLTT_ID(15), sizeof(sChatGPT_Palette));
 
     task->tState++;
@@ -1845,7 +1845,7 @@ bool8 ChatGPT_SetGfx(struct Task *task)
     u16 *tilemap, *tileset;
 
     GetBg0TilesDst(&tilemap, &tileset);
-    LZ77UnCompVram(sChatGPT_Tilemap, tilemap);
+    DecompressDataWithHeaderVram(sChatGPT_Tilemap, tilemap);
     SetSinWave((s16*)gScanlineEffectRegBuffers[0], 0, task->tSinIndex, 132, task->tAmplitude, DISPLAY_HEIGHT);
 
     task->tState++;


### PR DESCRIPTION
## Summary
- load the ChatGPT battle transition assets using smol-compressed resources and the standard header-aware decompression routine
- add build tooling rules so the ChatGPT transition tileset is generated like the other battle transition graphics

## Testing
- make graphics/battle_transitions/chatgpt.4bpp.smol *(fails: missing arm-none-eabi-gcc toolchain in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daeee3a5548322b798d739914f4d71